### PR TITLE
Correct Middle East and North Africa link

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -464,7 +464,7 @@ export default function Home(props) {
             </p>
           </a>
           <a
-            href="middle-east-north-africa"
+            href="/category/middle-east-north-africa"
             className={styles.card + " " + styles.cardHover}
           >
             <h1>


### PR DESCRIPTION
Fixes #3 . Add /category/ to the link to fix the Middle East and North Africa card link.